### PR TITLE
Add Foojay toolchain provider

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
 rootProject.name = "stacker"
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}


### PR DESCRIPTION
Otherwise it's likely those without JDK 21 will get a build failure.