### PR TITLE
Use tar instead of zip for the distribution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,5 +101,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: st
-          path: ./build/install/st/*
+          path: ./build/distributions/st.tar
           if-no-files-found: error

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ spotless {
 	}
 }
 
-tasks.named("distTar").configure {
+tasks.named("distZip").configure {
 	enabled = false
 }
 tasks.named("assemble").configure {


### PR DESCRIPTION
This preserves file permissions, which are needed for the executables
to be executable.