### PR TITLE
Fix native library paths

### DIFF
--- a/.github/workflows/build-deps.sh
+++ b/.github/workflows/build-deps.sh
@@ -89,6 +89,7 @@ function build() {
   cmake -S libssh2 -B libssh2/build \
     -DCMAKE_PREFIX_PATH="$deps;$deps/include/openssl" \
     -DCMAKE_INSTALL_PREFIX="$deps" \
+    -DCMAKE_SKIP_RPATH=TRUE \
     -DCMAKE_IGNORE_PREFIX_PATH="/usr" \
     -DCMAKE_OSX_ARCHITECTURES=$CMAKE_ARCH \
     -DCMAKE_BUILD_TYPE=Release \
@@ -103,15 +104,16 @@ function build() {
     -DBUILD_TESTS=OFF \
     -DCMAKE_PREFIX_PATH="$deps;$deps/include/openssl" \
     -DCMAKE_INSTALL_PREFIX="$deps" \
+    -DCMAKE_SKIP_RPATH=TRUE \
     -DCMAKE_IGNORE_PREFIX_PATH="/usr" \
     -DCMAKE_OSX_ARCHITECTURES=$CMAKE_ARCH \
     -DCMAKE_BUILD_TYPE=Release
   cmake --build libgit2/build --target install
 
   mkdir -p native/$OS_ARCH/
-  cp -vL $deps/{lib,lib64}/libcrypto.{dylib,so} native/$OS_ARCH/ || true
+  cp -vL $deps/{lib,lib64}/libcrypto.{3.dylib,so} native/$OS_ARCH/ || true
   cp -vL $deps/{lib,lib64}/libssl.{dylib,so} native/$OS_ARCH/ || true
-  cp -vL $deps/{lib,lib64}/libssh2.{dylib,so} native/$OS_ARCH/ || true
+  cp -vL $deps/{lib,lib64}/libssh2.{1.dylib,so} native/$OS_ARCH/ || true
   cp -vL $deps/lib/libgit2.{dylib,so} native/$OS_ARCH/ || true
 
   echo "Build complete."

--- a/src/main/kotlin/com/mattprecious/stacker/vc/native.kt
+++ b/src/main/kotlin/com/mattprecious/stacker/vc/native.kt
@@ -11,9 +11,9 @@ internal fun loadLibGit2() {
 	val osArch = System.getProperty("os.arch").lowercase(Locale.US)
 
 	if (osName.contains("mac")) {
-		loadLibrary("$osArch/libcrypto.dylib")
+		loadLibrary("$osArch/libcrypto.3.dylib")
 		loadLibrary("$osArch/libssl.dylib")
-		loadLibrary("$osArch/libssh2.dylib")
+		loadLibrary("$osArch/libssh2.1.dylib")
 		loadLibrary("$osArch/libgit2.dylib")
 	} else if (osName.contains("linux")) {
 		loadLibrary("$osArch/libcrypto.so")


### PR DESCRIPTION
Disable rpath on the builds so that local paths stop being bundled into the binaries. Aside from just being bad, this masks invalid library names/paths when developing locally since the local paths are a functioning fallback.

---

Not really sure if this works. Need to test on CI.