### PR TITLE
Fix native library linking

### DIFF
--- a/.github/workflows/build-deps.sh
+++ b/.github/workflows/build-deps.sh
@@ -79,7 +79,7 @@ function build() {
 
   git clone --depth 1 --branch openssl-3.1.3 https://github.com/openssl/openssl.git
   pushd openssl
-  ./Configure $OPENSSL_ARCH --prefix=$deps no-tests no-legacy
+  ./Configure $OPENSSL_ARCH --prefix=$deps -Wl,-rpath,"@loader_path" no-tests no-legacy
   make -j$CMAKE_BUILD_PARALLEL_LEVEL
   make -j$CMAKE_BUILD_PARALLEL_LEVEL install_sw
   popd
@@ -89,6 +89,7 @@ function build() {
   cmake -S libssh2 -B libssh2/build \
     -DCMAKE_PREFIX_PATH="$deps;$deps/include/openssl" \
     -DCMAKE_INSTALL_PREFIX="$deps" \
+    -DCMAKE_INSTALL_RPATH="@loader_path" \
     -DCMAKE_IGNORE_PREFIX_PATH="/usr" \
     -DCMAKE_OSX_ARCHITECTURES=$CMAKE_ARCH \
     -DCMAKE_BUILD_TYPE=Release \
@@ -103,15 +104,16 @@ function build() {
     -DBUILD_TESTS=OFF \
     -DCMAKE_PREFIX_PATH="$deps;$deps/include/openssl" \
     -DCMAKE_INSTALL_PREFIX="$deps" \
+    -DCMAKE_INSTALL_RPATH="@loader_path" \
     -DCMAKE_IGNORE_PREFIX_PATH="/usr" \
     -DCMAKE_OSX_ARCHITECTURES=$CMAKE_ARCH \
     -DCMAKE_BUILD_TYPE=Release
   cmake --build libgit2/build --target install
 
   mkdir -p native/$OS_ARCH/
-  cp -vL $deps/{lib,lib64}/libcrypto.{dylib,so} native/$OS_ARCH/ || true
+  cp -vL $deps/{lib,lib64}/libcrypto.{3.dylib,so} native/$OS_ARCH/ || true
   cp -vL $deps/{lib,lib64}/libssl.{dylib,so} native/$OS_ARCH/ || true
-  cp -vL $deps/{lib,lib64}/libssh2.{dylib,so} native/$OS_ARCH/ || true
+  cp -vL $deps/{lib,lib64}/libssh2.{1.dylib,so} native/$OS_ARCH/ || true
   cp -vL $deps/lib/libgit2.{dylib,so} native/$OS_ARCH/ || true
 
   echo "Build complete."

--- a/src/main/kotlin/com/mattprecious/stacker/vc/native.kt
+++ b/src/main/kotlin/com/mattprecious/stacker/vc/native.kt
@@ -11,14 +11,8 @@ internal fun loadLibGit2() {
 	val osArch = System.getProperty("os.arch").lowercase(Locale.US)
 
 	if (osName.contains("mac")) {
-		loadLibrary("$osArch/libcrypto.dylib")
-		loadLibrary("$osArch/libssl.dylib")
-		loadLibrary("$osArch/libssh2.dylib")
 		loadLibrary("$osArch/libgit2.dylib")
 	} else if (osName.contains("linux")) {
-		loadLibrary("$osArch/libcrypto.so")
-		loadLibrary("$osArch/libssl.so")
-		loadLibrary("$osArch/libssh2.so")
 		loadLibrary("$osArch/libgit2.so")
 	} else {
 		throw IllegalStateException("Unsupported OS: $osName")


### PR DESCRIPTION
This was only working for local development since project paths were
being included in the libraries when building. Pointing rpath to
"@loader_path" tells them to look in their relative directory when
loading other libraries.

The manual loading of the additional libraries was completely
unnecessary.