### PR TITLE
Add gradle-build-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,11 @@ jobs:
           distribution: 'zulu'
           java-version: 21
 
+      - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
+
       - name: Build native libraries
         run: ./build-deps.sh -c ${{ matrix.cmake-arch }} -o ${{ matrix.openssl-arch }} -s ${{ matrix.sqlite-arch }}
 


### PR DESCRIPTION
Should hopefully speed things up a little bit through its caching.
Won't see substantial gains until the build-deps work moves into a
gradle task.