### PR TITLE
Minor improvements to prompt/ansi code

### DIFF
--- a/src/commonMain/kotlin/com/mattprecious/stacker/rendering/ansi.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/rendering/ansi.kt
@@ -2,7 +2,7 @@ package com.mattprecious.stacker.rendering
 
 object Ansi {
 	const val clearEntireLine = "\u001B[2K"
-	const val cursorDown = "\u001b[B"
+	const val cursorDown = "\u001B[E"
 	const val cursorUp = "\u001B[F"
 	const val underline = "\u001B[4m"
 	const val reset = "\u001B[0m"

--- a/src/commonMain/kotlin/com/mattprecious/stacker/rendering/prompt.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/rendering/prompt.kt
@@ -6,6 +6,7 @@ import com.mattprecious.stacker.rendering.Ansi.cursorDown
 import com.mattprecious.stacker.rendering.Ansi.cursorUp
 import com.mattprecious.stacker.rendering.Ansi.reset
 import com.mattprecious.stacker.rendering.Ansi.restorePosition
+import com.mattprecious.stacker.rendering.Ansi.savePosition
 import com.mattprecious.stacker.rendering.Ansi.underline
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
@@ -39,8 +40,7 @@ fun <T> CliktCommand.interactivePrompt(
 		return options.single()
 	}
 
-	val builder = StringBuilder(options.size)
-	val outputTerminal = currentContext.terminal
+	val builder = StringBuilder()
 
 	val labelSuffix = if (message.last().isLetterOrDigit()) ": " else " "
 
@@ -82,11 +82,11 @@ fun <T> CliktCommand.interactivePrompt(
 			selected.let {
 				if (it == null) {
 					append(filter)
-					append(Ansi.savePosition)
+					append(savePosition)
 				} else {
 					val result = filteredOptions[it]
 					appendLine(valueTransform(result))
-					outputTerminal.rawPrint(toString())
+					print(toString())
 					return result
 				}
 			}
@@ -104,7 +104,7 @@ fun <T> CliktCommand.interactivePrompt(
 
 			append(restorePosition)
 
-			outputTerminal.rawPrint(toString())
+			print(toString())
 		}
 
 		withRaw {


### PR DESCRIPTION
- Removes usage of clikt terminal API since we're already bypassing it for the input handling and managing raw mode.
- Update the cursorDown code to the one that also moves the cursor to the start of the line. Not necessary, but matches cursorUp.
- Removes invalid starting capacity for the StringBuilder. This parameter is a character count, not a line count.