### PR TITLE
Build libgit2 as gradle task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,20 +20,11 @@ jobs:
         include:
           # TODO: Linking is not working on linux.
 #          - os: ubuntu-latest
-#            cmake-arch: x86_64
-#            openssl-arch: linux-x86_64
-#            sqlite-arch: x64-gnu-linux
 #            task: linkReleaseExecutableLinuxX64
           - os: macOS-latest
-            cmake-arch: x86_64
-            openssl-arch: darwin64-x86_64-cc
-            sqlite-arch: x64-apple-macos
             task: linkReleaseExecutableMacosX64
           # TODO: Cross-compilation is not working. There's so many dependencies that need to be manually built.
 #          - os: macOS-latest
-#            cmake-arch: arm64
-#            openssl-arch: darwin64-arm64-cc
-#            sqlite-arch: arm64-apple-macos
 #            task: linkReleaseExecutableMacosArm64
           # TODO: build on 'windows-latest'
 
@@ -47,12 +38,7 @@ jobs:
           java-version: 21
 
       - uses: gradle/gradle-build-action@v2
-        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
-        timeout-minutes: 5
         continue-on-error: true
-
-      - name: Build native libraries
-        run: ./build-deps.sh -c ${{ matrix.cmake-arch }} -o ${{ matrix.openssl-arch }} -s ${{ matrix.sqlite-arch }}
 
       - run: ./gradlew ${{ matrix.task }}
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 ## Development
 
-### Building Native Libraries
-
-This project uses [libgit2](https://github.com/libgit2/libgit2), which needs to be downloaded and built locally before
-the project will compile. This can be done by executing `./build-deps.sh`.
-
 ### Building
 
 The generic `assemble` and `build` tasks will attempt to build for all supported architectures, which cannot be done

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
+
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
 
 plugins {
 	alias(libs.plugins.spotless)
@@ -76,17 +77,35 @@ spotless {
 	}
 }
 
-val requireDepsTask = tasks.register("requireDepsFiles") {
-	outputs.upToDateWhen { false }
+val buildDependenciesTask = tasks.register<BuildDependenciesTask>("buildDependencies") {
+	script = layout.projectDirectory.file("build-deps.sh")
+	defFile = layout.projectDirectory.file("src/nativeInterop/cinterop/libgit2.def")
+	outputDir = layout.projectDirectory.dir("deps")
+}
 
-	doFirst {
-		check(file("src/nativeInterop/libgit2.def").exists()) {
-			".def file does not exist. This must be populated with paths to native libraries.\n" +
-				"If developing locally, please run ./build-deps.sh"
-		}
+abstract class BuildDependenciesTask : Exec() {
+	@get:InputFile
+	abstract val script: RegularFileProperty
+
+	@get:OutputFile
+	abstract val defFile: RegularFileProperty
+
+	@get:OutputDirectory
+	abstract val outputDir: DirectoryProperty
+
+	override fun exec() {
+		setExecutable(script.get().asFile)
+		setArgs(
+			listOf(
+				"-d", defFile.get().asFile.absolutePath,
+				"-b", outputDir.get().asFile.absolutePath,
+			)
+		)
+
+		super.exec()
 	}
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-	dependsOn(requireDepsTask)
+tasks.withType<CInteropProcess>().configureEach {
+	dependsOn(buildDependenciesTask)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
 


### PR DESCRIPTION
Since we're not building a multi-architecture binary on CI anymore, there's no need to complicate things with a script that needs to be manually executed.

Cross-compilation logic can be re-introduced later at this gradle task level instead.