### PR TITLE
Force libcurl to be statically linked

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,11 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         continue-on-error: true
 
+      - name: Uninstall Homebrew curl
+        if: matrix.os == 'macOS-13' || matrix.os == 'macOS-14'
+        # Forces libcurl to be statically linked by uninstalling the dynamic libs
+        run: brew uninstall --ignore-dependencies curl
+
       - run: ./gradlew ${{ matrix.task }}
 
       - name: Upload distribution


### PR DESCRIPTION
The TL;DR is that `ld` will always prefer a `.dylib` over a `.a` if it can find one.

I don't know how else to make it _not_ find this `.dylib`, but this works!