### PR TITLE
Remove the now unneeded TempFileSystem

### DIFF
--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
@@ -12,7 +12,7 @@ class SimpleTest {
 		stackerTest {
 			// TODO: Assert against the message that's printed as well.
 			assertThat(runStacker()).isEqualTo(-1)
-			assertThat(fileSystem.list("/".toPath())).isEmpty()
+			assertThat(fileSystem.list(".".toPath())).isEmpty()
 		}
 	}
 


### PR DESCRIPTION
Changing the working directory in 902bb183 also ends up changing the
working directory of FileSystem.SYSTEM, so using a forwarding system
is not only not needed, but the current implementation incorrectly
forwards us to the wrong location.