### PR TITLE
Use clikt's testing API

### DIFF
--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
@@ -3,15 +3,20 @@ package com.mattprecious.stacker.test
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.message
+import com.mattprecious.stacker.RepoNotFoundException
 import okio.Path.Companion.toPath
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class SimpleTest {
 	@Test
-	fun returnsErrorIfNoRepositoryFound() {
+	fun throwsErrorIfNoRepositoryFound() {
 		stackerTest {
-			// TODO: Assert against the message that's printed as well.
-			assertThat(runStacker()).isEqualTo(-1)
+			val t = assertFailsWith<RepoNotFoundException> { runStacker() }
+			assertThat(t).message()
+				.isEqualTo("No repository found at ${fileSystem.canonicalize(".".toPath())}.")
+
 			assertThat(fileSystem.list(".".toPath())).isEmpty()
 		}
 	}

--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/stackerTest.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/stackerTest.kt
@@ -1,5 +1,7 @@
 package com.mattprecious.stacker.test
 
+import com.github.ajalt.clikt.testing.CliktCommandTestResult
+import com.github.ajalt.clikt.testing.test
 import com.mattprecious.stacker.remote.FakeRemote
 import com.mattprecious.stacker.withStacker
 import kotlinx.cinterop.convert
@@ -56,13 +58,16 @@ class StackerTestScope(
 ) {
 	val remote = FakeRemote()
 
-	fun runStacker(vararg args: String): Int {
-		return withStacker(
+	fun runStacker(vararg args: String): CliktCommandTestResult {
+		var result: CliktCommandTestResult? = null
+		withStacker(
 			fileSystem = fileSystem,
 			remoteOverride = remote,
 		) {
-			it.parse(args.asList())
+			result = it.test(args.asList())
 		}
+
+		return result!!
 	}
 }
 


### PR DESCRIPTION
This allows easy assertions against output and status codes.

The repository check needed to be moved to an exception since we're
not inside a clikt command at that point in the application.