### PR TITLE
Add a test for db location

### DIFF
--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/SimpleTest.kt
@@ -3,6 +3,9 @@ package com.mattprecious.stacker.test
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.isZero
 import assertk.assertions.message
 import com.mattprecious.stacker.RepoNotFoundException
 import okio.Path.Companion.toPath
@@ -31,6 +34,19 @@ class SimpleTest {
 			environment.exec("git commit -m 'Testing'")
 			assertThat(environment.exec("git rev-parse HEAD"))
 				.isEqualTo("f8cdffa9a5c120b21a0042138806a930e72af88f")
+		}
+	}
+
+	@Test
+	fun dbIsCreatedInGitDirectory() {
+		stackerTest {
+			environment.exec("git init")
+			assertThat(fileSystem.exists(".git/stacker.db".toPath())).isFalse()
+
+			with(runStacker()) {
+				assertThat(statusCode).isZero()
+				assertThat(fileSystem.exists(".git/stacker.db".toPath())).isTrue()
+			}
 		}
 	}
 }


### PR DESCRIPTION
We can now initialize a git repository in the test environment and get
stacker through it's full startup sequence.