### PR TITLE
Improve defaults for trunk branch selection

### DIFF
--- a/src/commonMain/kotlin/com/mattprecious/stacker/vc/VersionControl.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/vc/VersionControl.kt
@@ -10,6 +10,9 @@ interface VersionControl : AutoCloseable {
 	val branches: List<String>
 	val editor: String?
 
+	/** The default branch name from git config. Not necessarily the trunk branch in this repo. */
+	val defaultBranch: String?
+
 	fun fallthrough(commands: List<String>)
 
 	fun checkBranches(branchNames: Set<String>): Set<String>


### PR DESCRIPTION
Rather than hard coding 'main', grab the default name from  git config
and fall back to the current branch.