### PR TITLE
Prompt even for one option for some commands

### DIFF
--- a/src/commonMain/kotlin/com/mattprecious/stacker/command/branch/Checkout.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/command/branch/Checkout.kt
@@ -27,6 +27,7 @@ internal class Checkout(
 			val options = stackManager.getBase()!!.prettyTree()
 			interactivePrompt(
 				message = "Checkout a branch",
+				promptIfSingle = true,
 				options = options,
 				default = options.find { it.branch.name == vc.currentBranchName },
 				displayTransform = { it.pretty },

--- a/src/commonMain/kotlin/com/mattprecious/stacker/command/repo/Init.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/command/repo/Init.kt
@@ -48,6 +48,7 @@ internal class Init(
 
 		val trunk = interactivePrompt(
 			message = "Select your trunk branch, which you open pull requests against",
+			promptIfSingle = true,
 			options = branches,
 			default = defaultTrunk,
 		)
@@ -64,9 +65,10 @@ internal class Init(
 			null
 		} else {
 			// TODO: This assumes that the trailing trunk branch already exists. It will fail if there's
-			//  only one branch in the repo, and will auto-select if there's only two.
+			//  only one branch in the repo.
 			interactivePrompt(
 				message = "Select your trailing trunk branch, which you branch from",
+				promptIfSingle = true,
 				options = branches.filterNot { it == trunk },
 				default = currentTrailingTrunk,
 			)

--- a/src/commonMain/kotlin/com/mattprecious/stacker/command/upstack/Onto.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/command/upstack/Onto.kt
@@ -42,6 +42,7 @@ internal class Onto(
 		val options = stackManager.getBase()!!.prettyTree { it.name != currentBranchName }
 		val newParent = interactivePrompt(
 			message = "Select the parent branch for ${currentBranchName.styleBranch()}",
+			promptIfSingle = true,
 			options = options,
 			default = options.find { it.branch.name == currentBranch.parent!!.name },
 			displayTransform = { it.pretty },

--- a/src/commonMain/kotlin/com/mattprecious/stacker/rendering/prompt.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/rendering/prompt.kt
@@ -31,12 +31,13 @@ fun <T> CliktCommand.interactivePrompt(
 	message: String,
 	options: List<T>,
 	filteringEnabled: Boolean = true,
+	promptIfSingle: Boolean = false,
 	default: T? = null,
 	displayTransform: (T) -> String = { it.toString() },
 	valueTransform: (T) -> String = { it.toString() },
 ): T {
 	require(options.isNotEmpty())
-	if (options.size == 1) {
+	if (!promptIfSingle && options.size == 1) {
 		return options.single()
 	}
 


### PR DESCRIPTION
For these commands, automatically selecting a branch for you might be
convenient, but it's also potentially confusing or destructive. Making
you choose ensures that you know what's happening and lets you confirm
that the right action is going to occur.