### PR TITLE
Use a fully filled circle for current branch

### DIFF
--- a/src/commonMain/kotlin/com/mattprecious/stacker/command/branches.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/command/branches.kt
@@ -49,7 +49,7 @@ private fun TreeNode<Branch>.prettyTree(
 		repeat(inset) { append("│ ") }
 
 		if (this@prettyTree.name == selected?.name) {
-			append("◉")
+			append("●")
 		} else {
 			append("○")
 		}


### PR DESCRIPTION
It's better. I don't know why I picked the other one.