### PR TITLE
Stop automatically building dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         # Forces libcurl to be statically linked by uninstalling the dynamic libs
         run: brew uninstall --ignore-dependencies curl
 
-      - run: ./gradlew ${{ matrix.task }}
+      - run: ./gradlew buildDependencies ${{ matrix.task }}
 
       - name: Upload distribution
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is such a heavy task to run with high chance of failure (like working offline), leaving you in a worse state than before you ran it. With the gradle caching logic being completely unreliable at times, this results in frequent rebuilds of these dependencies.

Move this task back to being explicit and restore the check task.