### PR TITLE
Improve test APIs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 coroutines = "1.10.1"
 kotlin = "2.1.10"
 ktor = "3.0.3"
-mosaic = "0.15.0"
+mosaic = "0.16.0"
 sqldelight = "2.0.2"
 
 [libraries]

--- a/src/commonMain/kotlin/com/mattprecious/stacker/command/StackerCommandScope.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/command/StackerCommandScope.kt
@@ -1,20 +1,21 @@
 package com.mattprecious.stacker.command
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshotFlow
 import com.jakewharton.mosaic.text.AnnotatedString
 import com.jakewharton.mosaic.text.buildAnnotatedString
+import com.mattprecious.stacker.command.StackerCommand.WorkState
 import com.mattprecious.stacker.config.ConfigManager
 import com.mattprecious.stacker.lock.Locker
 import com.mattprecious.stacker.rendering.Printer
 import com.mattprecious.stacker.rendering.code
 import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 
 class StackerCommandScope internal constructor(
 	private val printer: Printer,
-	private val state: MutableStateFlow<StackerCommand.State>,
+	private val workState: WorkState,
 ) {
 	fun printStatic(message: String) {
 		printer.printStatic(message)
@@ -35,10 +36,14 @@ class StackerCommandScope internal constructor(
 	}
 
 	suspend fun <R> render(content: @Composable (onResult: (R) -> Unit) -> Unit): R {
-		state.value = StackerCommand.State.Rendering(content)
-		return state.filterIsInstance<StackerCommand.State.DeliveringRenderResult<R>>().first().result.also {
-			state.value = StackerCommand.State.Working
-		}
+		workState.state = StackerCommand.State.Rendering(content)
+		return snapshotFlow { workState.state }
+			.filterIsInstance<StackerCommand.State.DeliveringRenderResult<R>>()
+			.first()
+			.result
+			.also {
+				workState.state = StackerCommand.State.Working
+			}
 	}
 
 	suspend fun requireInitialized(configManager: ConfigManager) {
@@ -70,8 +75,8 @@ class StackerCommandScope internal constructor(
 	}
 
 	suspend fun abort(): Nothing {
-		require(state.value !is StackerCommand.State.TerminalState)
-		state.value = StackerCommand.State.Aborted
+		require(workState.state !is StackerCommand.State.TerminalState)
+		workState.state = StackerCommand.State.Aborted
 		awaitCancellation()
 	}
 }

--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/RepoInitTest.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/RepoInitTest.kt
@@ -1,8 +1,6 @@
 package com.mattprecious.stacker.test
 
 import assertk.assertThat
-import assertk.assertions.isEmpty
-import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import com.mattprecious.stacker.command.repo.repoInit
 import kotlin.test.Test
@@ -13,13 +11,12 @@ class RepoInitTest {
 		gitInit()
 
 		testCommand({ repoInit() }) {
+			awaitFrame(
+				static = "Stacker cannot be initialized in a completely empty repository. " +
+					"Please make a commit first.",
+				output = "",
+			)
 			assertThat(awaitResult()).isFalse()
-			assertThat(awaitOutput()).isEmpty()
-			assertThat(awaitStatic())
-				.isEqualTo(
-					"Stacker cannot be initialized in a completely empty repository. " +
-						"Please make a commit first.",
-				)
 		}
 	}
 }

--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/mosaicTestUtils.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/mosaicTestUtils.kt
@@ -1,0 +1,55 @@
+package com.mattprecious.stacker.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import assertk.Assert
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+import com.jakewharton.mosaic.Mosaic
+import com.jakewharton.mosaic.layout.KeyEvent
+import com.jakewharton.mosaic.testing.TestMosaic
+import com.jakewharton.mosaic.ui.AnsiLevel
+import com.mattprecious.stacker.rendering.LocalPrinter
+import com.mattprecious.stacker.rendering.Printer
+
+// So the IDE doesn't trim trailing spaces in test assertions...
+val s = " "
+
+fun TestMosaic<Mosaic>.setContentWithStatics(
+	content: @Composable () -> Unit,
+): Mosaic {
+	return setContentAndSnapshot {
+		CompositionLocalProvider(
+			LocalPrinter provides Printer(),
+		) {
+			LocalPrinter.current.Messages()
+			content()
+		}
+	}
+}
+
+fun Assert<Mosaic>.matches(
+	output: String? = null,
+	static: String = "",
+) {
+	hasStaticsEqualTo(static)
+	output?.let(::hasOutputEqualTo)
+}
+
+fun Assert<Mosaic>.hasOutputEqualTo(expected: String) = given { actual ->
+	val renderedOutput = actual.paint().render(AnsiLevel.NONE)
+	if (renderedOutput != expected) {
+		expected("output:${show(expected)} but was output:${show(renderedOutput)}")
+	}
+}
+
+fun Assert<Mosaic>.hasStaticsEqualTo(expected: String) = given { actual ->
+	val renderedStatics = actual.paintStatics().joinToString("\n") { it.render(AnsiLevel.NONE) }
+	if (renderedStatics != expected) {
+		expected("static:${show(expected)} but was static:${show(renderedStatics)}")
+	}
+}
+
+fun TestMosaic<*>.sendText(text: String) {
+	text.forEach { sendKeyEvent(KeyEvent("$it")) }
+}


### PR DESCRIPTION
Asserting against statics and outputs separately hides a lot of weird
behaviors that can lead to incorrect/flakey tests.

Also, hook into the internal state machine to avoid races when the
command switches internally.