### PR TITLE
Remove default from LocalPrinter

### DIFF
--- a/src/commonMain/kotlin/com/mattprecious/stacker/rendering/printer.kt
+++ b/src/commonMain/kotlin/com/mattprecious/stacker/rendering/printer.kt
@@ -8,7 +8,7 @@ import com.jakewharton.mosaic.text.buildAnnotatedString
 import com.jakewharton.mosaic.ui.Static
 import com.jakewharton.mosaic.ui.Text
 
-val LocalPrinter = staticCompositionLocalOf { Printer() }
+val LocalPrinter = staticCompositionLocalOf<Printer> { throw AssertionError() }
 
 class Printer {
 	private val messages = SnapshotStateList<AnnotatedString>()


### PR DESCRIPTION
Not providing a printer will usually be incorrect, especially in tests
where this is a static reference that can leak across tests.