### PR TITLE
Properly set default git branch to 'main'

### DIFF
--- a/src/commonTest/kotlin/com/mattprecious/stacker/test/git.kt
+++ b/src/commonTest/kotlin/com/mattprecious/stacker/test/git.kt
@@ -3,7 +3,7 @@ package com.mattprecious.stacker.test
 import okio.Path
 
 fun TestEnvironment.gitInit() {
-	environment.exec("git init")
+	environment.exec("git init --initial-branch='main'")
 	gitSetDefaultBranch("main")
 }
 


### PR DESCRIPTION
Setting the config value after initializing the repo doesn't work,
obviously.